### PR TITLE
v0.2.17 Hotfix: Filepattern matching death spiral #11 #12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,17 +65,19 @@ git-graph: ##@git Log decorated graph
 # -- Project --
 .PHONY: run wrun debug test build-win build-linux build
 
+WGO_INCLUDE := -file .go -file .toml
+
 run: ##@run Run normally. Pass arguments like so: args="arg1 arg2 ...".
 	go run ./main.go $(args)
 
 wrun: ##@run Run and watch for file changes. Requires wgo: https://github.com/bokwoon95/wgo
-	wgo run ./main.go $(args)
+	wgo $(WGO_INCLUDE) go run ./main.go $(args)
 
 debug: ##@run Run and watch with the --test flag. Requires wgo: https://github.com/bokwoon95/wgo
-	wgo run . $(args) --test
+	wgo $(WGO_INCLUDE) go run . $(args) --test
 
 test: ##@run go test and watch. Requires wgo: https://github.com/bokwoon95/wgo
-	wgo -file .go go test -v ./...
+	wgo $(WGO_INCLUDE) go test -v ./...
 
 build-win: ##@build Build for windows. Binary will be located at ./build/
 	GOOS=windows GOARCH=amd64 go build -o ./build/BitburnerGoFilesync.exe ./main.go

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ The config file by default will be named `config.toml` and the initial content w
 |:-----|:------------|:-------:|
 | Port | Set the port for the server to connect to. | `"8080"` |
 | Directory | Specify the directory where this tool should watch for file changes to sync up with bitburner. | `"./"` |
-| FileScanInterval | The amount of miliseconds the file scanner waits each loop. | `100` |
+| FileScanInterval | The amount of miliseconds the file scanner waits each loop. | `1000` |
 | [FilePatterns] | Holds include and exclude file pattern matching fields which allow you to define which files to sync and which not to. | [Pattern matching rules](https://github.com/bmatcuk/doublestar?tab=readme-ov-file#patterns) |
-| - Include | Which files should be included. | `["**/*.js", "**/*.ts"]` |
-| - Exclude | Which files to ignore. This is checked before the include patterns.  | `["**/*.d.ts"]` |
+| - Include | Which files should be included. | `["*.js", "*.ts"]` |
+| - Exclude | Which files to ignore. This is checked before the include patterns.  | `["*.d.ts"]` |
 
 ## How to build
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,10 +24,10 @@ type TConfig struct {
 var Values = &TConfig{
 	Port:             "8080",
 	Directory:        "./",
-	FileScanInterval: 100,
+	FileScanInterval: 1000,
 	FilePatterns: TConfigFilrPatterns{
-		Include: []string{"**/*.js", "**/*.ts"},
-		Exclude: []string{"**/*.d.ts"},
+		Include: []string{"*.js", "*.ts"},
+		Exclude: []string{"*.d.ts"},
 	},
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -60,7 +60,7 @@ func validateConfigValues() {
 }
 
 func log(msg string) {
-	if !constants.Debug {
+	if !constants.Debug || !constants.LogConfig {
 		return
 	}
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -9,6 +9,8 @@ var WorkindDirectory, _ = os.Getwd()
 var ConfigFilePath = fmt.Sprintf("%s/%s", WorkindDirectory, "config.toml")
 
 var Debug = false
+var LogConfig = false
+
 var NoWatcher = false
 var NoServer = false
 

--- a/test/test.go
+++ b/test/test.go
@@ -12,7 +12,7 @@ func DoTest() {
 	println("\n")
 	fmt.Printf("%s: %v\n", "Port", config.Values.Port)
 	fmt.Printf("%s: %v\n", "WorkindDirectory", constants.WorkindDirectory)
-	fmt.Printf("%s: %v\n", "WorkindDirectory", constants.ConfigFilePath)
+	fmt.Printf("%s: %v\n", "ConfigFile", constants.ConfigFilePath)
 	fmt.Printf("%s: %v\n", "BitburnerRoot", config.Values.Directory)
 	fmt.Printf("%s: %v\n", "IncludeFileExt", config.Values.FilePatterns.Include)
 	fmt.Printf("%s: %v\n", "FileScanDelay", config.Values.FilePatterns.Exclude)
@@ -20,5 +20,7 @@ func DoTest() {
 	fmt.Printf("%s: %v\n", "NoServer", constants.NoServer)
 	fmt.Printf("%s: %v\n", "KeepAlive", constants.KeepAlive)
 	println("")
+
 	// watcher.FileScanner()
+	// watcher.Initialize()
 }

--- a/utils/file.go
+++ b/utils/file.go
@@ -14,14 +14,14 @@ import (
 func ForEachFileInDir(dir string, fn func(file os.FileInfo)) {
 	files, err := os.ReadDir(dir)
 	if err != nil {
-		println(err)
+		fmt.Printf("utils/ForEachFileInDir os.ReadDir(): %v\n", err)
 		return
 	}
 
 	for _, file := range files {
 		info, err := file.Info()
 		if err != nil {
-			println(err)
+			fmt.Printf("utils/ForEachFileInDir file.Info(): %v\n", err)
 			continue
 		}
 
@@ -51,7 +51,7 @@ func GetFileContentByPath(path string) []byte {
 	var filePath = GetAbsolutePath(path)
 
 	if !ctnfile.FileExists(filePath) {
-		fmt.Printf("utils/GetFileContentByPath: File does not exist: %s\n", filePath)
+		fmt.Printf("utils/GetFileContentByPath File does not exist: %s\n", filePath)
 		return []byte{}
 	}
 

--- a/watcher/fileState.go
+++ b/watcher/fileState.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/CTNOriginals/BitburnerGoFilesync/config"
+	"github.com/CTNOriginals/BitburnerGoFilesync/utils"
 	ctnmap "github.com/CTNOriginals/CTNGoUtils/v2/map"
 )
 
@@ -21,7 +22,7 @@ func (this FileInfo) String() string {
 
 // Gets the current os.FileInfo, not the info stored in this.info
 func (this FileInfo) GetInfo() os.FileInfo {
-	file, err := os.Stat(this.Path)
+	file, err := os.Stat(utils.GetAbsolutePath(this.Path))
 
 	if err != nil {
 		fmt.Printf("watchet/GetInfo os.Stat: %v\n", err)

--- a/watcher/fileState.go
+++ b/watcher/fileState.go
@@ -24,7 +24,7 @@ func (this FileInfo) GetInfo() os.FileInfo {
 	file, err := os.Stat(this.Path)
 
 	if err != nil {
-		println(err)
+		fmt.Printf("watchet/GetInfo os.Stat: %v\n", err)
 		return this.Info
 	}
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -42,7 +42,9 @@ func FileScanner() {
 // the event will be added to the state.
 func scanFiles() {
 	for path, state := range FileStateMap {
-		if !ctnfile.FileExists(path) {
+		var fullPath = utils.GetAbsolutePath(path)
+
+		if !ctnfile.FileExists(fullPath) {
 			FileEventHandlerMap.Handle(state, OnFileDelete)
 			continue
 		}
@@ -72,6 +74,13 @@ func getUnregisteredFiles(dir string) (newFiles []*FileInfo) {
 			path = file.Name()
 		} else {
 			path = fmt.Sprintf("%s/%s", reldir, file.Name())
+
+			// Remove the first '/' if it is present.
+			// This ensures a little more consistency
+			// revative to the paths that are at the root level.
+			if path[0] == '/' {
+				path = path[1:]
+			}
 		}
 
 		if !shouldIncludeFile(path) {

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -33,12 +33,12 @@ func TestPatternMatching(t *testing.T) {
 			testFilePattern("foo/bar/dir/index.d.ts", true)
 		})
 
-		Convey("Include **/*.ts Exclude **/*.d.ts", func() {
+		Convey("Include *.ts Exclude *.d.ts", func() {
 			config.Values.FilePatterns.Include = []string{
-				"**/*.ts",
+				"*.ts",
 			}
 			config.Values.FilePatterns.Exclude = []string{
-				"**/*.d.ts",
+				"*.d.ts",
 			}
 
 			Convey("Should return true", func() {
@@ -53,11 +53,33 @@ func TestPatternMatching(t *testing.T) {
 			})
 		})
 
+		Convey("Include **/*.ts Exclude **/*.d.ts", func() {
+			config.Values.FilePatterns.Include = []string{
+				"**/*.ts",
+			}
+			config.Values.FilePatterns.Exclude = []string{
+				"**/*.d.ts",
+			}
+
+			Convey("Should return true", func() {
+				testFilePattern("dir/index.ts", true)
+				testFilePattern("foo/bar/dir/index.ts", true)
+			})
+			Convey("Should return false", func() {
+				testFilePattern("index.ts", false)
+				testFilePattern("index.d.ts", false)
+				testFilePattern("dir/index.d.ts", false)
+				testFilePattern("foo/bar/dir/index.d.ts", false)
+			})
+		})
+
 		Convey("Include **/foo/** Exclude **/foo/bar/**", func() {
 			config.Values.FilePatterns.Include = []string{
+				"foo/**",
 				"**/foo/**",
 			}
 			config.Values.FilePatterns.Exclude = []string{
+				"foo/bar/**",
 				"**/foo/bar/**",
 			}
 


### PR DESCRIPTION
This patch fixes a bug that was introduced with #10 where the file patterns were not matching correctly which triggered a death spiral where files would get added and deleted rapidly.

The fix was related to correcting path references that were not absolute paths but should have been.

Thanks @crow0085 #11 and @bethany7 #12 for reporting this issue.