### PR TITLE
FEAT: NetscriptDefinitions download functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ The config file by default will be named `config.toml` and the initial content w
 | [Logging] | Control what is and isnt logged |  |
 | - NoColor | Prevent the logger from applying ansi color coding to the log prefix. | `false` |
 | - LogConfig | Enable config logging. | `false` |
+| [Handlers] | Controls for few small but useful features |  |
+| -[NSDefinitions] | Specify if and where to download the NetscriptDefinitions.d.ts file. |  |
+| - - Enable | Wether to download NetscriptDefinitions from bitburner the first time you connect to the remote. | `true` |
+| - - Destination | The file path destination of where to download the file to. If the path is not absolute, it will be relative to the location of the config.toml file. | `./` |
 
 ## How to build
 

--- a/arguments/arguments.go
+++ b/arguments/arguments.go
@@ -187,17 +187,6 @@ var argumentList = argList{
 			config.Values.FileScanInterval = int(num)
 		},
 	},
-	{Alias: []string{"--get-definitions"},
-		Description: []string{
-			"Currently not functional.",
-			"Requests the NetscriptDefinitions.d.ts file when a connection is established.",
-			"The definitions file will be created in bitburners root directory.",
-		},
-		Params: argParameters{},
-		Action: func(params []string) {
-			clog.Error("TODO: Handle --get-definitions")
-		},
-	},
 
 	{Alias: []string{"DEBUG ARGUMENTS"}},
 

--- a/arguments/arguments.go
+++ b/arguments/arguments.go
@@ -255,4 +255,13 @@ var argumentList = argList{
 			constants.NoCli = true
 		},
 	},
+	{Alias: []string{"--no-handlers"},
+		Description: []string{
+			"Prevents the program initializing the handlers.",
+		},
+		Params: argParameters{},
+		Action: func(params []string) {
+			constants.NoHandlers = true
+		},
+	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ var Values = &SConfig{
 		LogConfig: false,
 	},
 	Handlers: &SConfigHandlers{
-		NetscriptDefinitions: &SConfigHandlersNSDefinitions{
+		NSDefinitions: &SConfigHandlersNSDefinitions{
 			GetOnConnect: true,
 			Destination:  "./",
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type SConfig struct {
 	FileScanInterval int
 	FilePatterns     SConfigFilrPatterns
 	Logging          SConfigLogging
+	Handlers         *SConfigHandlers
 }
 
 var Values = &SConfig{
@@ -51,6 +52,12 @@ var Values = &SConfig{
 	Logging: SConfigLogging{
 		NoColor:   false,
 		LogConfig: false,
+	},
+	Handlers: &SConfigHandlers{
+		NetscriptDefinitions: &SConfigHandlersNSDefinitions{
+			GetOnConnect: true,
+			Destination:  "./",
+		},
 	},
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -55,8 +55,8 @@ var Values = &SConfig{
 	},
 	Handlers: &SConfigHandlers{
 		NSDefinitions: &SConfigHandlersNSDefinitions{
-			GetOnConnect: true,
-			Destination:  "./",
+			Enable:      true,
+			Destination: "./",
 		},
 	},
 }

--- a/config/handlers.go
+++ b/config/handlers.go
@@ -42,12 +42,12 @@ func (this *SConfigHandlersNSDefinitions) ValidateValues() error {
 }
 
 type SConfigHandlers struct {
-	NetscriptDefinitions *SConfigHandlersNSDefinitions
+	NSDefinitions *SConfigHandlersNSDefinitions
 }
 
 func (this *SConfigHandlers) ValidateValues() error {
 	var fields = []IConfigGroup{
-		this.NetscriptDefinitions,
+		this.NSDefinitions,
 	}
 
 	for _, field := range fields {

--- a/config/handlers.go
+++ b/config/handlers.go
@@ -8,8 +8,8 @@ import (
 )
 
 type SConfigHandlersNSDefinitions struct {
-	GetOnConnect bool
-	Destination  string
+	Enable      bool
+	Destination string
 }
 
 func (this *SConfigHandlersNSDefinitions) ValidateValues() error {

--- a/config/handlers.go
+++ b/config/handlers.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/CTNOriginals/BitburnerGoFilesync/constants"
 )
 
 type SConfigHandlersNSDefinitions struct {
@@ -12,8 +14,7 @@ type SConfigHandlersNSDefinitions struct {
 
 func (this *SConfigHandlersNSDefinitions) ValidateValues() error {
 	var fileExists = func() error {
-		var stat, err = os.Stat(this.Destination)
-		clog.Debugf("nsdef path: %s", stat.Name())
+		var _, err = os.Stat(this.Destination)
 		return err
 	}
 
@@ -21,16 +22,21 @@ func (this *SConfigHandlersNSDefinitions) ValidateValues() error {
 		return fileExists()
 	}
 
-	// TODO: finish this
-	// this.Destination = filepath.Clean(this.Destination)
-	//
-	// var relpath, err = filepath.Rel(Values.Directory, this.Destination)
-	//
-	// if err != nil {
-	// 	return err
-	// }
-	//
-	// this.Destination = relpath
+	var baseDir = filepath.Dir(constants.ConfigFilePath)
+
+	this.Destination = filepath.Clean(filepath.Join(baseDir, this.Destination))
+
+	if filepath.IsAbs(this.Destination) {
+		return fileExists()
+	}
+
+	var abspath, err = filepath.Abs(this.Destination)
+
+	if err != nil {
+		return err
+	}
+
+	this.Destination = abspath
 
 	return fileExists()
 }

--- a/config/handlers.go
+++ b/config/handlers.go
@@ -1,12 +1,38 @@
 package config
 
+import (
+	"os"
+	"path/filepath"
+)
+
 type SConfigHandlersNSDefinitions struct {
 	GetOnConnect bool
 	Destination  string
 }
 
 func (this *SConfigHandlersNSDefinitions) ValidateValues() error {
-	return nil
+	var fileExists = func() error {
+		var stat, err = os.Stat(this.Destination)
+		clog.Debugf("nsdef path: %s", stat.Name())
+		return err
+	}
+
+	if filepath.IsAbs(this.Destination) {
+		return fileExists()
+	}
+
+	// TODO: finish this
+	// this.Destination = filepath.Clean(this.Destination)
+	//
+	// var relpath, err = filepath.Rel(Values.Directory, this.Destination)
+	//
+	// if err != nil {
+	// 	return err
+	// }
+	//
+	// this.Destination = relpath
+
+	return fileExists()
 }
 
 type SConfigHandlers struct {

--- a/config/handlers.go
+++ b/config/handlers.go
@@ -1,0 +1,29 @@
+package config
+
+type SConfigHandlersNSDefinitions struct {
+	GetOnConnect bool
+	Destination  string
+}
+
+func (this *SConfigHandlersNSDefinitions) ValidateValues() error {
+	return nil
+}
+
+type SConfigHandlers struct {
+	NetscriptDefinitions *SConfigHandlersNSDefinitions
+}
+
+func (this *SConfigHandlers) ValidateValues() error {
+	var fields = []IConfigGroup{
+		this.NetscriptDefinitions,
+	}
+
+	for _, field := range fields {
+		var err = field.ValidateValues()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -17,9 +17,10 @@ var ConfigFilePath = fmt.Sprintf("%s/%s", WorkindDirectory, "config.toml")
 var Debug = false
 
 var (
-	NoWatcher = false
-	NoServer  = false
-	NoCli     = false
+	NoWatcher  = false
+	NoServer   = false
+	NoCli      = false
+	NoHandlers = false
 )
 
 func init() {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1,0 +1,9 @@
+// This package handles some functionality that does
+// not fit inside its own dedicated package.
+package handlers
+
+var NetscriptDefinitions *SNetscriptDefinitions
+
+func Initialize() {
+	NetscriptDefinitions = newNetscriptDefinitions()
+}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -8,7 +8,7 @@ var clog = clogger.Default.Clone(clogger.SClog{
 	Name: "handlers",
 })
 
-var NetscriptDefinitions *SNetscriptDefinitions
+var NetscriptDefinitions *SNSDefinitions
 
 func Initialize() {
 	NetscriptDefinitions = newNetscriptDefinitions()

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,6 +2,12 @@
 // not fit inside its own dedicated package.
 package handlers
 
+import "github.com/CTNOriginals/BitburnerGoFilesync/clogger"
+
+var clog = clogger.Default.Clone(clogger.SClog{
+	Name: "handlers",
+})
+
 var NetscriptDefinitions *SNetscriptDefinitions
 
 func Initialize() {

--- a/handlers/netscriptDefinitions.go
+++ b/handlers/netscriptDefinitions.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -21,14 +22,27 @@ func newNetscriptDefinitions() *SNetscriptDefinitions {
 
 func (this SNetscriptDefinitions) clientOnConnect() (unsub bool) {
 	// TODO: add a config option to disable this function from running
-	// TODO: add dedicated config field for nsdef destination dir
-	var dest = config.Values.Directory
+
+	var dest = config.Values.Handlers.NetscriptDefinitions.Destination
+
+	var stat, err = os.Stat(dest)
+
+	if err != nil {
+		clog.Errorf("Unable to download NetscriptDefinitions to %s:\n%v", dest, err)
+		return true
+	}
+
+	var destFile = dest
+
+	if stat.IsDir() {
+		destFile = filepath.Join(dest, "NetscriptDefinitions.d.ts")
+	}
 
 	clog.Debugf("Downloading NetscriptDefinitions to %s", dest)
 
 	websocket.Client.Socket.GetDefinitionFile(func(result *websocket.Result_GetDefinitionFile) {
 		var content = string(*result)
-		ctnfile.WriteFile(filepath.Join(dest, "NetscriptDefinitions.d.ts"), strings.Split(content, "\n"))
+		ctnfile.WriteFile(destFile, strings.Split(content, "\n"))
 	})
 
 	return true

--- a/handlers/netscriptDefinitions.go
+++ b/handlers/netscriptDefinitions.go
@@ -15,14 +15,14 @@ type SNetscriptDefinitions struct{}
 func newNetscriptDefinitions() *SNetscriptDefinitions {
 	var nsdef = &SNetscriptDefinitions{}
 
-	websocket.Client.OnReadySubCallback(nsdef.clientOnConnect)
+	if config.Values.Handlers.NetscriptDefinitions.GetOnConnect == true {
+		websocket.Client.OnReadySubCallback(nsdef.clientOnConnect)
+	}
 
 	return nsdef
 }
 
 func (this SNetscriptDefinitions) clientOnConnect() (unsub bool) {
-	// TODO: add a config option to disable this function from running
-
 	var dest = config.Values.Handlers.NetscriptDefinitions.Destination
 
 	var stat, err = os.Stat(dest)

--- a/handlers/netscriptDefinitions.go
+++ b/handlers/netscriptDefinitions.go
@@ -1,12 +1,35 @@
 package handlers
 
-type SNetscriptDefinitions struct {
-}
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/CTNOriginals/BitburnerGoFilesync/config"
+	"github.com/CTNOriginals/BitburnerGoFilesync/websocket"
+	ctnfile "github.com/CTNOriginals/CTNGoUtils/v2/file"
+)
+
+type SNetscriptDefinitions struct{}
 
 func newNetscriptDefinitions() *SNetscriptDefinitions {
-	return &SNetscriptDefinitions{}
+	var nsdef = &SNetscriptDefinitions{}
+
+	websocket.Client.OnReadySubCallback(nsdef.clientOnConnect)
+
+	return nsdef
 }
 
-func (this SNetscriptDefinitions) clientOnConnect() {
+func (this SNetscriptDefinitions) clientOnConnect() (unsub bool) {
+	// TODO: add a config option to disable this function from running
+	// TODO: add dedicated config field for nsdef destination dir
+	var dest = config.Values.Directory
 
+	clog.Debugf("Downloading NetscriptDefinitions to %s", dest)
+
+	websocket.Client.Socket.GetDefinitionFile(func(result *websocket.Result_GetDefinitionFile) {
+		var content = string(*result)
+		ctnfile.WriteFile(filepath.Join(dest, "NetscriptDefinitions.d.ts"), strings.Split(content, "\n"))
+	})
+
+	return true
 }

--- a/handlers/netscriptDefinitions.go
+++ b/handlers/netscriptDefinitions.go
@@ -1,0 +1,12 @@
+package handlers
+
+type SNetscriptDefinitions struct {
+}
+
+func newNetscriptDefinitions() *SNetscriptDefinitions {
+	return &SNetscriptDefinitions{}
+}
+
+func (this SNetscriptDefinitions) clientOnConnect() {
+
+}

--- a/handlers/nsDefinitions.go
+++ b/handlers/nsDefinitions.go
@@ -10,20 +10,20 @@ import (
 	ctnfile "github.com/CTNOriginals/CTNGoUtils/v2/file"
 )
 
-type SNetscriptDefinitions struct{}
+type SNSDefinitions struct{}
 
-func newNetscriptDefinitions() *SNetscriptDefinitions {
-	var nsdef = &SNetscriptDefinitions{}
+func newNetscriptDefinitions() *SNSDefinitions {
+	var nsdef = &SNSDefinitions{}
 
-	if config.Values.Handlers.NetscriptDefinitions.GetOnConnect == true {
+	if config.Values.Handlers.NSDefinitions.GetOnConnect == true {
 		websocket.Client.OnReadySubCallback(nsdef.clientOnConnect)
 	}
 
 	return nsdef
 }
 
-func (this SNetscriptDefinitions) clientOnConnect() (unsub bool) {
-	var dest = config.Values.Handlers.NetscriptDefinitions.Destination
+func (this SNSDefinitions) clientOnConnect() (unsub bool) {
+	var dest = config.Values.Handlers.NSDefinitions.Destination
 
 	var stat, err = os.Stat(dest)
 

--- a/handlers/nsDefinitions.go
+++ b/handlers/nsDefinitions.go
@@ -15,7 +15,7 @@ type SNSDefinitions struct{}
 func newNetscriptDefinitions() *SNSDefinitions {
 	var nsdef = &SNSDefinitions{}
 
-	if config.Values.Handlers.NSDefinitions.GetOnConnect == true {
+	if config.Values.Handlers.NSDefinitions.Enable == true {
 		websocket.Client.OnReadySubCallback(nsdef.clientOnConnect)
 	}
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CTNOriginals/BitburnerGoFilesync/clogger"
 	"github.com/CTNOriginals/BitburnerGoFilesync/config"
 	"github.com/CTNOriginals/BitburnerGoFilesync/constants"
+	"github.com/CTNOriginals/BitburnerGoFilesync/handlers"
 	"github.com/CTNOriginals/BitburnerGoFilesync/watcher"
 	"github.com/CTNOriginals/BitburnerGoFilesync/websocket"
 )
@@ -45,6 +46,10 @@ func main() {
 	config.Initialize()
 
 	arguments.ParseSpecificArgs(args, false, "--config")
+
+	if !constants.NoHandlers {
+		handlers.Initialize()
+	}
 
 	if !constants.NoCli {
 		go cli.CommandWatcher()

--- a/watcher/tests.go
+++ b/watcher/tests.go
@@ -45,7 +45,7 @@ func testFileEvents() {
 	Initialize()
 	go StartScanner()
 
-	<-*websocket.Client.OnReadySub()
+	<-*websocket.Client.OnReadySubNotify()
 
 	ctnfile.WriteFile(delPath, []string{"bout to be gone"})
 	ctnfile.WriteFile(newPath, []string{"brand new"})

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -31,7 +31,7 @@ func Initialize() {
 }
 
 func StartScanner() {
-	<-*websocket.Client.OnReadySub()
+	<-*websocket.Client.OnReadySubNotify()
 	for {
 		fileStateMap.GetNewEntries(rootDir, func(path string) {
 			var err = fileStateMap.Push(path)

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -103,7 +103,7 @@ func (this *SClient) onReady() {
 	// Call each subscribed callback
 	for i, sub := range this.onReadyCallback {
 		// if callback returns true: unsubscribe
-		if !sub() {
+		if sub() {
 			this.onReadyCallback = slices.Delete(this.onReadyCallback, i, i+1)
 		}
 	}

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -8,12 +8,16 @@ import (
 	wsgorilla "github.com/gorilla/websocket"
 )
 
+type FnOnReadyCallback func() (unsub bool)
+
 type SClient struct {
 	Connection *wsgorilla.Conn
 	Socket     *SSocket
 
-	onReadyNotify []*chan bool
-	mutex         sync.Mutex
+	onReadyNotify   []*chan bool
+	onReadyCallback []FnOnReadyCallback
+
+	mutex sync.Mutex
 }
 
 func (this *SClient) Active() bool {
@@ -86,12 +90,18 @@ func (this *SClient) onReady() {
 	this.Connection.SetCloseHandler(this.onClose)
 	this.Socket.Open()
 
-	if len(this.onReadyNotify) > 0 {
-		// Unblock any scripts waiting on this signal
-		for i, sub := range this.onReadyNotify {
-			*sub <- true
-			close(*sub)
-			this.onReadyNotify = slices.Delete(this.onReadyNotify, i, i+1)
+	// Unblock any scripts waiting on this signal
+	for i, sub := range this.onReadyNotify {
+		*sub <- true
+		close(*sub)
+		this.onReadyNotify = slices.Delete(this.onReadyNotify, i, i+1)
+	}
+
+	// Call each subscribed callback
+	for i, sub := range this.onReadyCallback {
+		// if callback returns true: unsubscribe
+		if !sub() {
+			this.onReadyCallback = slices.Delete(this.onReadyCallback, i, i+1)
 		}
 	}
 
@@ -113,6 +123,18 @@ func (this *SClient) OnReadySub() *chan bool {
 	this.onReadyNotify = append(this.onReadyNotify, &sub)
 
 	return &sub
+}
+
+// Subscribe with a callback that will be called each time [SClient.onReady] is called.
+func (this *SClient) OnReadySubCallback(cb FnOnReadyCallback) {
+	this.mutex.Lock()
+	defer this.mutex.Unlock()
+
+	if this.onReadyCallback == nil {
+		this.onReadyCallback = make([]FnOnReadyCallback, 0)
+	}
+
+	this.onReadyCallback = append(this.onReadyCallback, cb)
 }
 
 func (this *SClient) onConnect(w http.ResponseWriter, r *http.Request) {

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -111,7 +111,7 @@ func (this *SClient) onReady() {
 	clog.Infof("Ready!")
 }
 
-func (this *SClient) OnReadySub() *chan bool {
+func (this *SClient) OnReadySubNotify() *chan bool {
 	this.mutex.Lock()
 	defer this.mutex.Unlock()
 

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -90,6 +90,9 @@ func (this *SClient) onReady() {
 	this.Connection.SetCloseHandler(this.onClose)
 	this.Socket.Open()
 
+	go this.sender()
+	go this.listener()
+
 	// Unblock any scripts waiting on this signal
 	for i, sub := range this.onReadyNotify {
 		*sub <- true
@@ -104,9 +107,6 @@ func (this *SClient) onReady() {
 			this.onReadyCallback = slices.Delete(this.onReadyCallback, i, i+1)
 		}
 	}
-
-	go this.sender()
-	go this.listener()
 
 	clog.Infof("Ready!")
 }

--- a/websocket/socket.go
+++ b/websocket/socket.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 )
 
@@ -79,7 +80,20 @@ func (this *SSocket) receive(body json.RawMessage) {
 	}
 
 	var message, exists = this.Messages[response.Id]
-	clog.Debugf("Received message: %s", string(body))
+	clog.Debugf("Received message: %s", func() string {
+		var content = string(body)
+		var cutoff = 100
+		var sep = fmt.Sprintf(" ...[%d characters]... ", len(content)-cutoff)
+
+		if len(content) <= cutoff+len(sep) {
+			return content
+		}
+
+		var lhs = content[:(cutoff/2)+1]
+		var rhs = content[len(content)-(cutoff/2):]
+
+		return lhs + sep + rhs
+	}())
 
 	if !exists {
 		clog.Errorf("Message id does not exist: %d\n", response.Id)

--- a/websocket/tests.go
+++ b/websocket/tests.go
@@ -9,7 +9,7 @@ func TestClient() {
 	go Client.Start(config.Values.Port)
 	defer Client.Close()
 
-	<-*Client.OnReadySub()
+	<-*Client.OnReadySubNotify()
 	clog.Debug("OnReady!")
 
 	Client.Socket.GetAllFiles(Params_GetAllFiles{


### PR DESCRIPTION
- **create(package): handlers**
- **func(websocket): client add OnReadySubCallback**
- **refac(websocket): rename OnReadySub to OnReadySubNotify**
- **impl(handlers): initialize in main**
- **fix(websocket): client call onReady subs post sender/listener start**
- **fix(websocket): socket cutoff large message body log**
- **fix(websocket/client): on ready callback unsubscribe**
- **impl(handlers/netdef): base netscriptdefinitions download functionality**
- **create(config): handlers**
- **wip(config/handlers): NSDefinitions validator**
- **func(config/handlers): implement nsdefinitons path validation**
- **impl(handlers/nsdef): config destinaiton path**
- **impl(handlers/nsdef): config enable/disable option**
- **clean(arguments): remove --get-definitions**
- **refac(nsDefinitions): rename NetscriptDefinitions to NSDefinitions**
- **refac(config/handlers): rename field GetOnConnect to Enable**
- **doc(readme): add new config field rows**
